### PR TITLE
Code quality, MCP server, PDF fallback, Markdown support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+GEMINI_API_KEY=your-gemini-api-key
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_KEY=your-supabase-service-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.venv/
 uploads/
 __pycache__/
 *.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,23 +12,52 @@ Multimodal RAG application that embeds text, images, video, audio, and PDFs usin
 # Install dependencies
 pip install -r requirements.txt
 
-# Run the app
+# Run the Streamlit app
 streamlit run app.py
+
+# Run the MCP server (stdio transport)
+python mcp_server.py
 ```
 
 ## Architecture
 
-- **app.py** — Streamlit GUI with three tabs: Upload & Embed (multi-file), Search (with image/video display), Browse (with delete)
-- **lib/embedder.py** — Wraps `google-genai` SDK. Uses `gemini-embedding-2-preview` model (3072 dims, L2-normalized). All content types go through `embed_content()` with `Part.from_bytes` for binary data. Query embeddings use `task_type="RETRIEVAL_QUERY"`, documents use `"RETRIEVAL_DOCUMENT"`.
-- **lib/chunker.py** — Splits oversized content: text (~6000 token chunks), PDF (5-page chunks via PyMuPDF), audio (75s via pydub), video (120s via moviepy)
-- **lib/db.py** — Supabase client. Inserts documents with embeddings, runs vector search via `match_documents()` RPC, stats, delete.
-- **lib/rag.py** — Orchestrates ingest (detect type → chunk → embed → store) and query (embed query → vector search → reasoning). Images/videos are stored as base64 in `file_data` column.
-- **lib/reasoning.py** — Sends query + retrieved context to Gemini 3.1 Flash Lite (`gemini-3.1-flash-lite-preview`) with source citation instructions.
+- **app.py** — Streamlit GUI with three tabs: Upload & Embed (multi-file, per-collection), Search (with image/video display, collection filter), Browse (table view, delete by filename or ID). Sidebar shows live DB stats and settings.
+- **mcp_server.py** — FastMCP server (stdio) exposing four tools: `search_documents`, `search_and_reason`, `list_collections`, `document_stats`. Configured in `.mcp.json` for Claude Desktop.
+- **lib/gemini_client.py** — Module-level singleton (`get_client()`) for `google.genai.Client`. Both `embedder.py` and `reasoning.py` import from here to share one authenticated client.
+- **lib/embedder.py** — Wraps `google-genai` SDK. Uses `gemini-embedding-2-preview` model (3072 dims, L2-normalized). All content types go through `embed_content()` with `Part.from_bytes` for binary data. Query embeddings use `task_type="RETRIEVAL_QUERY"`, documents use `"RETRIEVAL_DOCUMENT"`. Retries on `ResourceExhausted`, `ServiceUnavailable`, `DeadlineExceeded`, `InternalServerError`, and `ConnectionError` with exponential backoff (base 60 s, up to 3 attempts).
+- **lib/chunker.py** — Splits oversized content: text (~6000 token chunks with 500 token overlap), PDF (5-page sub-PDFs via PyMuPDF), audio (75 s via pydub), video (120 s via moviepy). Also exposes `extract_pdf_text()` for text extraction alongside embedding.
+- **lib/db.py** — Supabase client singleton. Key functions: `insert_document()`, `search_documents()` (via `match_documents()` RPC), `get_all_documents()`, `get_collections()`, `get_existing_chunks()` (duplicate detection), `delete_document()` (by ID), `delete_by_filename()` (batch delete), `get_stats()`.
+- **lib/rag.py** — Orchestrates ingest (detect type → get existing chunks → chunk → embed → store, skipping duplicates) and query (embed query → vector search → optional reasoning). Accepts `on_progress` callback for UI progress bars. Images and videos are stored as base64 in the `file_data` column.
+- **lib/reasoning.py** — Sends query + retrieved context chunks to Gemini 3.1 Flash Lite (`gemini-3.1-flash-lite-preview`) via `get_client().models.generate_content()` with a system instruction that requires numbered source citations.
 
 ## Database
 
-Supabase project `lgllivbqhqmpkcbmacyy`. The `documents` table has a `vector(3072)` embedding column (no HNSW — pgvector's limit is 2000 dims, so exact search is used). The `match_documents()` RPC performs cosine similarity search with optional content type filtering. Images/videos are stored as base64 in the `file_data` TEXT column.
+Supabase project `lgllivbqhqmpkcbmacyy`. The `documents` table schema:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | uuid | Primary key |
+| `title` | text | User-supplied title |
+| `content_type` | text | `text`, `image`, `pdf`, `audio`, `video` |
+| `original_filename` | text | Used for duplicate detection and batch delete |
+| `chunk_index` | int | 0-based chunk position |
+| `chunk_total` | int | Total chunks for this file |
+| `text_content` | text | Extracted text (NULL for binary-only types) |
+| `file_data` | text | Base64-encoded binary (images and videos only) |
+| `metadata` | jsonb | Type-specific metadata (mime_type, size, pages, etc.) |
+| `embedding` | vector(3072) | L2-normalized; exact search (no HNSW — pgvector's HNSW limit is 2000 dims) |
+| `collection` | text | Collection name, default `"default"` |
+| `created_at` | timestamptz | Auto-set |
+
+The `match_documents()` RPC performs cosine similarity search with optional `filter_type` and `filter_collection` parameters.
 
 ## Environment
 
 Requires `.env` with: `GEMINI_API_KEY`, `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`.
+
+## Key Design Decisions
+
+- **No HNSW index**: pgvector's HNSW is limited to 2000 dimensions; at 3072 dims the query falls back to exact (sequential) scan.
+- **Duplicate detection**: `get_existing_chunks()` queries by `original_filename` before embedding; already-stored chunk indices are skipped. This allows resuming interrupted uploads without re-embedding.
+- **Shared Gemini client**: `gemini_client.py` prevents multiple `google.genai.Client` instances from being created across modules.
+- **`mcp` package**: `mcp_server.py` requires the `mcp` package (FastMCP). It is not listed in `requirements.txt` — install separately with `pip install mcp` if using the MCP server.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,17 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code
+(claude.ai/code) when working with code in this
+repository.
 
 ## Project Overview
 
-Multimodal RAG application that embeds text, images, video, audio, and PDFs using Google's Gemini Embedding model, stores vectors in Supabase (pgvector), and uses Gemini 3.1 Flash Lite for reasoning. Single Streamlit monolith — no separate backend. Only Google APIs are used (no OpenAI dependency).
+Multimodal RAG application that embeds text, images,
+video, audio, and PDFs using Google's Gemini Embedding
+model, stores vectors in Supabase (pgvector), and uses
+Gemini 3.1 Flash Lite for reasoning. Single Streamlit
+monolith — no separate backend. Only Google APIs are
+used (no OpenAI dependency).
 
 ## Commands
 
@@ -21,43 +28,102 @@ python mcp_server.py
 
 ## Architecture
 
-- **app.py** — Streamlit GUI with three tabs: Upload & Embed (multi-file, per-collection), Search (with image/video display, collection filter), Browse (table view, delete by filename or ID). Sidebar shows live DB stats and settings.
-- **mcp_server.py** — FastMCP server (stdio) exposing four tools: `search_documents`, `search_and_reason`, `list_collections`, `document_stats`. Configured in `.mcp.json` for Claude Desktop.
-- **lib/gemini_client.py** — Module-level singleton (`get_client()`) for `google.genai.Client`. Both `embedder.py` and `reasoning.py` import from here to share one authenticated client.
-- **lib/embedder.py** — Wraps `google-genai` SDK. Uses `gemini-embedding-2-preview` model (3072 dims, L2-normalized). All content types go through `embed_content()` with `Part.from_bytes` for binary data. Query embeddings use `task_type="RETRIEVAL_QUERY"`, documents use `"RETRIEVAL_DOCUMENT"`. Retries on `ResourceExhausted`, `ServiceUnavailable`, `DeadlineExceeded`, `InternalServerError`, and `ConnectionError` with exponential backoff (base 60 s, up to 3 attempts).
-- **lib/chunker.py** — Splits oversized content: text (~6000 token chunks with 500 token overlap), PDF (5-page sub-PDFs via PyMuPDF), audio (75 s via pydub), video (120 s via moviepy). Also exposes `extract_pdf_text()` for text extraction alongside embedding.
-- **lib/db.py** — Supabase client singleton. Key functions: `insert_document()`, `search_documents()` (via `match_documents()` RPC), `get_all_documents()`, `get_collections()`, `get_existing_chunks()` (duplicate detection), `delete_document()` (by ID), `delete_by_filename()` (batch delete), `get_stats()`.
-- **lib/rag.py** — Orchestrates ingest (detect type → get existing chunks → chunk → embed → store, skipping duplicates) and query (embed query → vector search → optional reasoning). Accepts `on_progress` callback for UI progress bars. Images and videos are stored as base64 in the `file_data` column.
-- **lib/reasoning.py** — Sends query + retrieved context chunks to Gemini 3.1 Flash Lite (`gemini-3.1-flash-lite-preview`) via `get_client().models.generate_content()` with a system instruction that requires numbered source citations.
+- **app.py** — Streamlit GUI with three tabs:
+  Upload & Embed (multi-file, per-collection),
+  Search (with image/video display, collection
+  filter), Browse (table view, delete by filename
+  or ID). Sidebar shows live DB stats and settings.
+- **mcp_server.py** — FastMCP server (stdio) exposing
+  four tools: `search_documents`,
+  `search_and_reason`, `list_collections`,
+  `document_stats`. Configured in `.mcp.json` for
+  Claude Desktop.
+- **lib/gemini_client.py** — Module-level singleton
+  (`get_client()`) for `google.genai.Client`. Both
+  `embedder.py` and `reasoning.py` import from here
+  to share one authenticated client.
+- **lib/embedder.py** — Wraps `google-genai` SDK.
+  Uses `gemini-embedding-2-preview` model (3072 dims,
+  L2-normalized). All content types go through
+  `embed_content()` with `Part.from_bytes` for binary
+  data. Query embeddings use
+  `task_type="RETRIEVAL_QUERY"`, documents use
+  `"RETRIEVAL_DOCUMENT"`. Retries on
+  `ResourceExhausted`, `ServiceUnavailable`,
+  `DeadlineExceeded`, `InternalServerError`, and
+  `ConnectionError` with exponential backoff (base
+  60 s, up to 3 attempts).
+- **lib/chunker.py** — Splits oversized content:
+  text (~6000 token chunks with 500 token overlap),
+  PDF (5-page sub-PDFs via PyMuPDF), audio (75 s via
+  pydub), video (120 s via moviepy). Also exposes
+  `extract_pdf_text()` for text extraction alongside
+  embedding.
+- **lib/db.py** — Supabase client singleton. Key
+  functions: `insert_document()`,
+  `search_documents()` (via `match_documents()` RPC),
+  `get_all_documents()`, `get_collections()`,
+  `get_existing_chunks()` (duplicate detection),
+  `delete_document()` (by ID),
+  `delete_by_filename()` (batch delete),
+  `get_stats()`.
+- **lib/rag.py** — Orchestrates ingest (detect type
+  → get existing chunks → chunk → embed → store,
+  skipping duplicates) and query (embed query →
+  vector search → optional reasoning). Accepts
+  `on_progress` callback for UI progress bars.
+  Images and videos are stored as base64 in the
+  `file_data` column.
+- **lib/reasoning.py** — Sends query + retrieved
+  context chunks to Gemini 3.1 Flash Lite
+  (`gemini-3.1-flash-lite-preview`) via
+  `get_client().models.generate_content()` with a
+  system instruction that requires numbered source
+  citations.
 
 ## Database
 
-Supabase project `lgllivbqhqmpkcbmacyy`. The `documents` table schema:
+Supabase project `lgllivbqhqmpkcbmacyy`.
+The `documents` table schema:
 
 | Column | Type | Notes |
-|--------|------|-------|
+| ------ | ---- | ----- |
 | `id` | uuid | Primary key |
 | `title` | text | User-supplied title |
 | `content_type` | text | `text`, `image`, `pdf`, `audio`, `video` |
 | `original_filename` | text | Used for duplicate detection and batch delete |
 | `chunk_index` | int | 0-based chunk position |
 | `chunk_total` | int | Total chunks for this file |
-| `text_content` | text | Extracted text (NULL for binary-only types) |
-| `file_data` | text | Base64-encoded binary (images and videos only) |
-| `metadata` | jsonb | Type-specific metadata (mime_type, size, pages, etc.) |
-| `embedding` | vector(3072) | L2-normalized; exact search (no HNSW — pgvector's HNSW limit is 2000 dims) |
+| `text_content` | text | Extracted text (NULL for binary-only) |
+| `file_data` | text | Base64-encoded binary (images/videos) |
+| `metadata` | jsonb | Type-specific metadata (mime, size, etc.) |
+| `embedding` | vector(3072) | L2-normalized; exact search (no HNSW) |
 | `collection` | text | Collection name, default `"default"` |
 | `created_at` | timestamptz | Auto-set |
 
-The `match_documents()` RPC performs cosine similarity search with optional `filter_type` and `filter_collection` parameters.
+The `match_documents()` RPC performs cosine similarity
+search with optional `filter_type` and
+`filter_collection` parameters.
 
 ## Environment
 
-Requires `.env` with: `GEMINI_API_KEY`, `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`.
+Requires `.env` with: `GEMINI_API_KEY`,
+`SUPABASE_URL`, `SUPABASE_SERVICE_KEY`.
 
 ## Key Design Decisions
 
-- **No HNSW index**: pgvector's HNSW is limited to 2000 dimensions; at 3072 dims the query falls back to exact (sequential) scan.
-- **Duplicate detection**: `get_existing_chunks()` queries by `original_filename` before embedding; already-stored chunk indices are skipped. This allows resuming interrupted uploads without re-embedding.
-- **Shared Gemini client**: `gemini_client.py` prevents multiple `google.genai.Client` instances from being created across modules.
-- **`mcp` package**: `mcp_server.py` requires the `mcp` package (FastMCP). It is not listed in `requirements.txt` — install separately with `pip install mcp` if using the MCP server.
+- **No HNSW index**: pgvector's HNSW is limited to
+  2000 dimensions; at 3072 dims the query falls back
+  to exact (sequential) scan.
+- **Duplicate detection**: `get_existing_chunks()`
+  queries by `original_filename` before embedding;
+  already-stored chunk indices are skipped. This
+  allows resuming interrupted uploads without
+  re-embedding.
+- **Shared Gemini client**: `gemini_client.py`
+  prevents multiple `google.genai.Client` instances
+  from being created across modules.
+- **`mcp` package**: `mcp_server.py` requires the
+  `mcp` package (FastMCP). It is not listed in
+  `requirements.txt` — install separately with
+  `pip install mcp` if using the MCP server.

--- a/Info for scaling.md
+++ b/Info for scaling.md
@@ -2,40 +2,60 @@
 
 ## Data Storage
 
-- Images and videos are stored as **Base64 strings** directly in the `file_data` column of the Supabase DB — no paths or links to original sources
+- Images and videos are stored as **Base64 strings**
+  directly in the `file_data` column of the
+  Supabase DB — no paths or links to original sources
 - Base64 inflates data by ~33%
-- Audio is embedded, but the bytes are **not** stored — audio can be found but not played back (bug)
-- Text and PDF store the extracted text in `text_content`
+- Audio bytes are stored as Base64 in `file_data`
+  (same as images and videos)
+- Text and PDF store the extracted text in
+  `text_content`
 
 ## Supabase Storage Limits
 
-- **Free plan**: 500 MB — sufficient for ~700 images or ~20–70 video chunks
-- **Pro plan**: 8 GB included ($25/mo), then $0.125/GB
-- Video-heavy usage fills the DB quickly / gets expensive
+- **Free plan**: 500 MB — sufficient for ~700 images
+  or ~20–70 video chunks
+- **Pro plan**: 8 GB included ($25/mo),
+  then $0.125/GB
+- Video-heavy usage fills the DB quickly / gets
+  expensive
 
 ## Recommendation for Scaling
 
-- Move binary data (images, videos, audio) to **Supabase Storage** or an S3 bucket
-- Store only the **storage path/URL** + embedding in the DB
-- On search: take the URL from the result, load the file from storage, and display it
+- Move binary data (images, videos, audio) to
+  **Supabase Storage** or an S3 bucket
+- Store only the **storage path/URL** + embedding
+  in the DB
+- On search: take the URL from the result, load the
+  file from storage, and display it
 
 ## Performance
 
-- **No HNSW index** possible — pgvector only supports HNSW up to 2000 dims, our embeddings have 3072
-- Search is therefore **brute-force (exact)** and scales linearly with the number of documents
-- With thousands of docs, search becomes noticeably slower
+- **No HNSW index** possible — pgvector only supports
+  HNSW up to 2000 dims, our embeddings have 3072
+- Search is therefore **brute-force (exact)** and
+  scales linearly with the number of documents
+- With thousands of docs, search becomes noticeably
+  slower
 
 ## Security
 
-- `SUPABASE_SERVICE_KEY` bypasses Row Level Security — fine for a local prototype, but a security risk in public deployments
+- `SUPABASE_SERVICE_KEY` bypasses Row Level
+  Security — fine for a local prototype, but a
+  security risk in public deployments
 
 ## Cost Pitfalls
 
-- Every video/audio chunk = one Gemini Embedding API call
-- Every search with Codex reasoning = one additional LLM call
+- Every video/audio chunk = one Gemini Embedding
+  API call
+- Every search with reasoning = one additional
+  LLM call
 - API costs can rise quickly during bulk ingests
 
 ## Chunking Limitations
 
-- Video chunks are fixed at 120s, audio at 75s — no intelligent splitting (e.g., at scene changes or silence)
-- Relevant moments can be split at chunk boundaries and become harder to find
+- Video chunks are fixed at 120s, audio at 75s — no
+  intelligent splitting (e.g., at scene changes or
+  silence)
+- Relevant moments can be split at chunk boundaries
+  and become harder to find

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ server for programmatic access.
    pip install -r requirements.txt
    ```
 
-2. Create a `.env` file with your API keys:
+2. Create a `.env` file with your API keys
+   (see `.env.example`):
 
    ```text
    GEMINI_API_KEY=your-key
@@ -24,7 +25,12 @@ server for programmatic access.
    SUPABASE_SERVICE_KEY=your-key
    ```
 
-3. Run the app:
+3. Set up the Supabase database — run `schema.sql`
+   in the Supabase SQL Editor (or via `psql`).
+   This creates the `documents` table, enables
+   pgvector, and adds the required RPC functions.
+
+4. Run the app:
 
    ```bash
    streamlit run app.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Multimodal RAG with Gemini Embedding
 
-A Retrieval-Augmented Generation application that embeds multiple content types — text, images, video, audio, and PDFs — using Google's Gemini Embedding 2 model, stores vectors in Supabase (pgvector), and uses Gemini 3.1 Flash Lite for reasoning. Built as a single Streamlit app.
+A Retrieval-Augmented Generation application that embeds multiple content types — text, images, video, audio, and PDFs — using Google's Gemini Embedding 2 model, stores vectors in Supabase (pgvector), and uses Gemini 3.1 Flash Lite for reasoning.
+Built as a single Streamlit app with an optional MCP server for programmatic access.
 
 ## Setup
 
@@ -24,46 +25,96 @@ A Retrieval-Augmented Generation application that embeds multiple content types 
 ## Features
 
 ### Upload & Embed
-- Upload one or multiple files at once (text, images, PDFs, audio, video)
+
+- Upload one or multiple files at once (text, Markdown, images, PDFs, audio, video)
+- Assign each batch to a named **collection** for thematic grouping
 - Files that exceed size limits are automatically chunked:
-  - **Text**: ~6000 token chunks with 500 token overlap
+  - **Text / Markdown**: ~6000 token chunks with 500 token overlap
   - **PDF**: 5-page chunks via PyMuPDF
   - **Audio**: 75-second segments via pydub
   - **Video**: 120-second segments via moviepy
+- **Duplicate detection**: chunks already stored for a given filename are skipped,
+  allowing interrupted uploads to resume without re-embedding
+- Per-file progress bar and status text during embedding
 - All embeddings are L2-normalized before storage
 
 ### Search
+
 - Natural language queries embedded with `RETRIEVAL_QUERY` task type
 - Vector similarity search via Supabase RPC (cosine distance)
-- Configurable top-k and similarity threshold
-- Filter results by content type
-- Images are displayed inline in search results
-- Optional reasoning via Gemini 3.1 Flash Lite with source citations
+- Configurable top-k (1–50) and similarity threshold (0.0–1.0, default 0.3)
+- Filter results by content type and by collection
+- Images and videos displayed inline in search results
+- Optional reasoning via Gemini 3.1 Flash Lite with numbered source citations
 
 ### Browse
-- View all stored documents in a table
-- Delete documents by ID
+
+- View all stored documents in a table (ID, title, type, filename, chunk, collection, created)
+- Delete all chunks of a file by filename
+- Delete a single chunk by document ID
+
+### Sidebar
+
+- Live database statistics (total chunks, counts per content type)
+- Collection filter applied to searches
+- Stats refresh on demand
 
 ## Architecture
 
 ```
-app.py              Streamlit GUI (upload, search, browse tabs)
+app.py              Streamlit GUI (upload, search, browse tabs + sidebar)
+mcp_server.py       MCP server exposing RAG search as tools
 lib/
-├── embedder.py     Gemini Embedding 2 (3072 dims) for all content types
-├── chunker.py      Content-aware chunking (text, PDF, audio, video)
-├── db.py           Supabase vector operations (insert, search, stats)
-├── rag.py          RAG pipeline orchestration (ingest + query)
-└── reasoning.py    Gemini 3.1 Flash Lite reasoning with source citations
+├── gemini_client.py  Shared google-genai client singleton
+├── embedder.py       Gemini Embedding 2 (3072 dims) with exponential-backoff retry
+├── chunker.py        Content-aware chunking (text, PDF, audio, video)
+├── db.py             Supabase vector operations (insert, search, delete, stats)
+├── rag.py            RAG pipeline orchestration (ingest + query)
+└── reasoning.py      Gemini 3.1 Flash Lite reasoning with source citations
 ```
+
+## MCP Server
+
+`mcp_server.py` exposes four tools over the MCP protocol (stdio transport),
+allowing any MCP-compatible client (e.g. Claude Desktop) to query the RAG index directly.
+
+### Available tools
+
+| Tool | Description |
+|------|-------------|
+| `search_documents` | Semantic vector search; returns ranked source excerpts |
+| `search_and_reason` | Vector search + Gemini Flash Lite reasoning; returns answer and sources |
+| `list_collections` | Lists all available document collections |
+| `document_stats` | Returns total chunk count and per-content-type breakdown |
+
+### Tool parameters (search tools)
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | string | required | Natural language search query |
+| `top_k` | int | 10 | Maximum results to return (1–50) |
+| `threshold` | float | 0.3 | Minimum cosine similarity (0.0–1.0) |
+| `content_type` | string | `"all"` | Filter: `all`, `text`, `image`, `pdf`, `audio`, `video` |
+| `collection` | string | `"all"` | Collection name or `"all"` |
+
+### Running the MCP server
+
+```bash
+python mcp_server.py
+```
+
+The server runs over stdio by default. The `.mcp.json` in the project root
+pre-configures it for use with Claude Desktop using the local `.venv` interpreter.
 
 ## Tech Stack
 
 | Component | Technology |
 |-----------|------------|
-| Embeddings | Gemini Embedding 2 Preview (3072 dims) |
+| Embeddings | Gemini Embedding 2 Preview (`gemini-embedding-2-preview`, 3072 dims) |
+| Reasoning | Gemini 3.1 Flash Lite (`gemini-3.1-flash-lite-preview`) |
 | Vector DB | Supabase + pgvector |
-| Reasoning | Gemini 3.1 Flash Lite |
 | GUI | Streamlit |
+| MCP server | FastMCP (stdio) |
 | PDF | PyMuPDF |
 | Audio | pydub |
 | Video | moviepy |

--- a/README.md
+++ b/README.md
@@ -1,23 +1,31 @@
 # Multimodal RAG with Gemini Embedding
 
-A Retrieval-Augmented Generation application that embeds multiple content types — text, images, video, audio, and PDFs — using Google's Gemini Embedding 2 model, stores vectors in Supabase (pgvector), and uses Gemini 3.1 Flash Lite for reasoning.
-Built as a single Streamlit app with an optional MCP server for programmatic access.
+A Retrieval-Augmented Generation application that
+embeds multiple content types — text, images, video,
+audio, and PDFs — using Google's Gemini Embedding 2
+model, stores vectors in Supabase (pgvector), and
+uses Gemini 3.1 Flash Lite for reasoning.
+Built as a single Streamlit app with an optional MCP
+server for programmatic access.
 
 ## Setup
 
 1. Install dependencies:
+
    ```bash
    pip install -r requirements.txt
    ```
 
 2. Create a `.env` file with your API keys:
-   ```
+
+   ```text
    GEMINI_API_KEY=your-key
    SUPABASE_URL=https://your-project.supabase.co
    SUPABASE_SERVICE_KEY=your-key
    ```
 
 3. Run the app:
+
    ```bash
    streamlit run app.py
    ```
@@ -26,76 +34,92 @@ Built as a single Streamlit app with an optional MCP server for programmatic acc
 
 ### Upload & Embed
 
-- Upload one or multiple files at once (text, Markdown, images, PDFs, audio, video)
-- Assign each batch to a named **collection** for thematic grouping
-- Files that exceed size limits are automatically chunked:
-  - **Text / Markdown**: ~6000 token chunks with 500 token overlap
+- Upload one or multiple files at once (text,
+  Markdown, images, PDFs, audio, video)
+- Assign each batch to a named **collection** for
+  thematic grouping
+- Files that exceed size limits are automatically
+  chunked:
+  - **Text / Markdown**: ~6000 token chunks with
+    500 token overlap
   - **PDF**: 5-page chunks via PyMuPDF
   - **Audio**: 75-second segments via pydub
   - **Video**: 120-second segments via moviepy
-- **Duplicate detection**: chunks already stored for a given filename are skipped,
-  allowing interrupted uploads to resume without re-embedding
-- Per-file progress bar and status text during embedding
+- **Duplicate detection**: chunks already stored for
+  a given filename are skipped, allowing interrupted
+  uploads to resume without re-embedding
+- Per-file progress bar and status text during
+  embedding
 - All embeddings are L2-normalized before storage
 
 ### Search
 
-- Natural language queries embedded with `RETRIEVAL_QUERY` task type
-- Vector similarity search via Supabase RPC (cosine distance)
-- Configurable top-k (1–50) and similarity threshold (0.0–1.0, default 0.3)
+- Natural language queries embedded with
+  `RETRIEVAL_QUERY` task type
+- Vector similarity search via Supabase RPC
+  (cosine distance)
+- Configurable top-k (1–50) and similarity threshold
+  (0.0–1.0, default 0.3)
 - Filter results by content type and by collection
-- Images and videos displayed inline in search results
-- Optional reasoning via Gemini 3.1 Flash Lite with numbered source citations
+- Images and videos displayed inline in search
+  results
+- Optional reasoning via Gemini 3.1 Flash Lite with
+  numbered source citations
 
 ### Browse
 
-- View all stored documents in a table (ID, title, type, filename, chunk, collection, created)
+- View all stored documents in a table (ID, title,
+  type, filename, chunk, collection, created)
 - Delete all chunks of a file by filename
 - Delete a single chunk by document ID
 
 ### Sidebar
 
-- Live database statistics (total chunks, counts per content type)
+- Live database statistics (total chunks, counts
+  per content type)
 - Collection filter applied to searches
 - Stats refresh on demand
 
 ## Architecture
 
-```
-app.py              Streamlit GUI (upload, search, browse tabs + sidebar)
-mcp_server.py       MCP server exposing RAG search as tools
+```text
+app.py            Streamlit GUI
+                  (upload, search, browse + sidebar)
+mcp_server.py     MCP server exposing RAG search
 lib/
-├── gemini_client.py  Shared google-genai client singleton
-├── embedder.py       Gemini Embedding 2 (3072 dims) with exponential-backoff retry
-├── chunker.py        Content-aware chunking (text, PDF, audio, video)
-├── db.py             Supabase vector operations (insert, search, delete, stats)
-├── rag.py            RAG pipeline orchestration (ingest + query)
-└── reasoning.py      Gemini 3.1 Flash Lite reasoning with source citations
+├── gemini_client.py  Shared google-genai client
+├── embedder.py       Gemini Embedding 2 (3072d)
+├── chunker.py        Content-aware chunking
+├── db.py             Supabase vector operations
+├── rag.py            RAG pipeline orchestration
+└── reasoning.py      Gemini Flash Lite reasoning
 ```
 
 ## MCP Server
 
-`mcp_server.py` exposes four tools over the MCP protocol (stdio transport),
-allowing any MCP-compatible client (e.g. Claude Desktop) to query the RAG index directly.
+`mcp_server.py` exposes four tools over the MCP
+protocol (stdio transport), allowing any
+MCP-compatible client (e.g. Claude Desktop) to query
+the RAG index directly.
 
 ### Available tools
 
 | Tool | Description |
-|------|-------------|
-| `search_documents` | Semantic vector search; returns ranked source excerpts |
-| `search_and_reason` | Vector search + Gemini Flash Lite reasoning; returns answer and sources |
+| ---- | ----------- |
+| `search_documents` | Semantic vector search; returns ranked excerpts |
+| `search_and_reason` | Vector search + Gemini reasoning; returns answer |
 | `list_collections` | Lists all available document collections |
-| `document_stats` | Returns total chunk count and per-content-type breakdown |
+| `document_stats` | Returns chunk count and per-type breakdown |
 
 ### Tool parameters (search tools)
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `query` | string | required | Natural language search query |
-| `top_k` | int | 10 | Maximum results to return (1–50) |
-| `threshold` | float | 0.3 | Minimum cosine similarity (0.0–1.0) |
-| `content_type` | string | `"all"` | Filter: `all`, `text`, `image`, `pdf`, `audio`, `video` |
-| `collection` | string | `"all"` | Collection name or `"all"` |
+| --------- | ---- | ------- | ----------- |
+| `query` | string | required | Search query |
+| `top_k` | int | 10 | Max results (1–50) |
+| `threshold` | float | 0.3 | Min similarity |
+| `content_type` | string | `"all"` | Type filter |
+| `collection` | string | `"all"` | Collection filter |
 
 ### Running the MCP server
 
@@ -103,15 +127,17 @@ allowing any MCP-compatible client (e.g. Claude Desktop) to query the RAG index 
 python mcp_server.py
 ```
 
-The server runs over stdio by default. The `.mcp.json` in the project root
-pre-configures it for use with Claude Desktop using the local `.venv` interpreter.
+The server runs over stdio by default.
+The `.mcp.json` in the project root pre-configures
+it for use with Claude Desktop using the local
+`.venv` interpreter.
 
 ## Tech Stack
 
 | Component | Technology |
-|-----------|------------|
-| Embeddings | Gemini Embedding 2 Preview (`gemini-embedding-2-preview`, 3072 dims) |
-| Reasoning | Gemini 3.1 Flash Lite (`gemini-3.1-flash-lite-preview`) |
+| --------- | ---------- |
+| Embeddings | Gemini Embedding 2 Preview (3072d) |
+| Reasoning | Gemini 3.1 Flash Lite |
 | Vector DB | Supabase + pgvector |
 | GUI | Streamlit |
 | MCP server | FastMCP (stdio) |

--- a/app.py
+++ b/app.py
@@ -13,14 +13,18 @@ st.title("Multimodal RAG with Gemini Embedding")
 with st.sidebar:
     st.header("Settings")
     top_k = st.slider("Top K results", 1, 50, 10)
-    threshold = st.slider("Similarity threshold", 0.0, 1.0, 0.5, 0.05)
+    threshold = st.slider("Similarity threshold", 0.0, 1.0, 0.3, 0.05)
     filter_type = st.selectbox(
         "Content type filter",
         ["all", "text", "image", "pdf", "audio", "video"],
     )
 
+    @st.cache_data(ttl=60)
+    def _collections():
+        return db.get_collections()
+
     try:
-        collections = db.get_collections()
+        collections = _collections()
     except Exception:
         collections = []
     filter_collection = st.selectbox(
@@ -55,7 +59,7 @@ with tab_upload:
     st.subheader("Upload files to embed")
     uploaded_files = st.file_uploader(
         "Choose one or more files",
-        type=["txt", "png", "jpg", "jpeg", "webp", "gif", "pdf", "mp3", "wav", "mp4", "mov", "avi"],
+        type=["txt", "md", "png", "jpg", "jpeg", "webp", "gif", "pdf", "mp3", "wav", "mp4", "mov", "avi"],
         accept_multiple_files=True,
     )
     title = st.text_input("Document title (applied to all files)", placeholder="My document")
@@ -94,6 +98,7 @@ with tab_upload:
                     raise
             st.success(f"Stored {total_stored} chunk(s) across {len(uploaded_files)} file(s)")
             st.cache_data.clear()
+            st.rerun()
     elif uploaded_files and (not title or not col_choice):
         st.warning("Please enter a document title and select a collection.")
 

--- a/lib/chunker.py
+++ b/lib/chunker.py
@@ -23,31 +23,24 @@ def chunk_text(text: str, max_tokens: int = 6000, overlap: int = 500) -> list[st
 
 def chunk_pdf(pdf_bytes: bytes, max_pages: int = 5) -> list[bytes]:
     """Split a PDF into sub-PDFs of at most max_pages pages. Returns list of PDF bytes."""
-    src = fitz.open(stream=pdf_bytes, filetype="pdf")
-    total = len(src)
-    if total <= max_pages:
-        src.close()
-        return [pdf_bytes]
-    chunks = []
-    for start in range(0, total, max_pages):
-        end = min(start + max_pages, total)
-        dst = fitz.open()
-        dst.insert_pdf(src, from_page=start, to_page=end - 1)
-        buf = dst.tobytes()
-        dst.close()
-        chunks.append(buf)
-    src.close()
-    return chunks
+    with fitz.open(stream=pdf_bytes, filetype="pdf") as src:
+        total = len(src)
+        if total <= max_pages:
+            return [pdf_bytes]
+        chunks = []
+        for start in range(0, total, max_pages):
+            end = min(start + max_pages, total)
+            with fitz.open() as dst:
+                dst.insert_pdf(src, from_page=start, to_page=end - 1)
+                chunks.append(dst.tobytes())
+        return chunks
 
 
-def extract_pdf_text(pdf_bytes: bytes) -> str:
-    """Extract all text from a PDF."""
-    doc = fitz.open(stream=pdf_bytes, filetype="pdf")
-    text = ""
-    for page in doc:
-        text += page.get_text()
-    doc.close()
-    return text
+def extract_pdf_text(pdf_bytes: bytes) -> tuple[str, int]:
+    """Extract all text and page count from a PDF."""
+    with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
+        text = "".join(page.get_text() for page in doc)
+        return text, len(doc)
 
 
 def chunk_audio(audio_bytes: bytes, fmt: str = "mp3", max_seconds: int = 75) -> list[bytes]:
@@ -85,19 +78,20 @@ def chunk_video(video_bytes: bytes, suffix: str = ".mp4", max_seconds: int = 120
             return [video_bytes]
         chunks = []
         t = 0
-        idx = 0
         while t < duration:
             end = min(t + max_seconds, duration)
             sub = clip.subclipped(t, end)
             tmp_out = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+            tmp_out_name = tmp_out.name
             tmp_out.close()
-            sub.write_videofile(tmp_out.name, logger=None)
-            with open(tmp_out.name, "rb") as f:
-                chunks.append(f.read())
-            os.unlink(tmp_out.name)
+            try:
+                sub.write_videofile(tmp_out_name, logger=None)
+                with open(tmp_out_name, "rb") as f:
+                    chunks.append(f.read())
+            finally:
+                os.unlink(tmp_out_name)
             sub.close()
             t = end
-            idx += 1
         clip.close()
         return chunks
     finally:

--- a/lib/db.py
+++ b/lib/db.py
@@ -83,23 +83,9 @@ def get_all_documents() -> list[dict]:
 
 
 def get_collections() -> list[str]:
-    """Return sorted list of distinct collection names."""
-    all_rows = []
-    offset = 0
-    page_size = 1000
-    while True:
-        result = (
-            get_client()
-            .table("documents")
-            .select("collection")
-            .range(offset, offset + page_size - 1)
-            .execute()
-        )
-        all_rows.extend(result.data)
-        if len(result.data) < page_size:
-            break
-        offset += page_size
-    return sorted({r["collection"] for r in all_rows})
+    """Return sorted list of distinct collection names via RPC."""
+    result = get_client().rpc("get_distinct_collections").execute()
+    return [r["collection"] for r in result.data]
 
 
 def get_existing_chunks(original_filename: str) -> set[int]:
@@ -131,24 +117,8 @@ def delete_by_filename(original_filename: str) -> int:
 
 
 def get_stats() -> dict:
-    all_rows = []
-    offset = 0
-    page_size = 1000
-    while True:
-        result = (
-            get_client()
-            .table("documents")
-            .select("content_type")
-            .range(offset, offset + page_size - 1)
-            .execute()
-        )
-        all_rows.extend(result.data)
-        if len(result.data) < page_size:
-            break
-        offset += page_size
-    total = len(all_rows)
-    by_type: dict[str, int] = {}
-    for r in all_rows:
-        ct = r["content_type"]
-        by_type[ct] = by_type.get(ct, 0) + 1
+    """Return total count and per-type breakdown via RPC."""
+    result = get_client().rpc("get_document_stats").execute()
+    by_type = {r["content_type"]: r["cnt"] for r in result.data}
+    total = sum(by_type.values())
     return {"total": total, "by_type": by_type}

--- a/lib/db.py
+++ b/lib/db.py
@@ -63,14 +63,23 @@ def search_documents(
 
 
 def get_all_documents() -> list[dict]:
-    result = (
-        get_client()
-        .table("documents")
-        .select("id, title, content_type, original_filename, chunk_index, chunk_total, collection, created_at")
-        .order("created_at", desc=True)
-        .execute()
-    )
-    return result.data
+    all_rows = []
+    offset = 0
+    page_size = 1000
+    while True:
+        result = (
+            get_client()
+            .table("documents")
+            .select("id, title, content_type, original_filename, chunk_index, chunk_total, collection, created_at")
+            .order("created_at", desc=True)
+            .range(offset, offset + page_size - 1)
+            .execute()
+        )
+        all_rows.extend(result.data)
+        if len(result.data) < page_size:
+            break
+        offset += page_size
+    return all_rows
 
 
 def get_collections() -> list[str]:
@@ -113,16 +122,24 @@ def delete_by_filename(original_filename: str) -> int:
 
 
 def get_stats() -> dict:
-    result = (
-        get_client()
-        .table("documents")
-        .select("content_type")
-        .execute()
-    )
-    rows = result.data
-    total = len(rows)
+    all_rows = []
+    offset = 0
+    page_size = 1000
+    while True:
+        result = (
+            get_client()
+            .table("documents")
+            .select("content_type")
+            .range(offset, offset + page_size - 1)
+            .execute()
+        )
+        all_rows.extend(result.data)
+        if len(result.data) < page_size:
+            break
+        offset += page_size
+    total = len(all_rows)
     by_type: dict[str, int] = {}
-    for r in rows:
+    for r in all_rows:
         ct = r["content_type"]
         by_type[ct] = by_type.get(ct, 0) + 1
     return {"total": total, "by_type": by_type}

--- a/lib/db.py
+++ b/lib/db.py
@@ -84,13 +84,22 @@ def get_all_documents() -> list[dict]:
 
 def get_collections() -> list[str]:
     """Return sorted list of distinct collection names."""
-    result = (
-        get_client()
-        .table("documents")
-        .select("collection")
-        .execute()
-    )
-    return sorted(set(r["collection"] for r in result.data))
+    all_rows = []
+    offset = 0
+    page_size = 1000
+    while True:
+        result = (
+            get_client()
+            .table("documents")
+            .select("collection")
+            .range(offset, offset + page_size - 1)
+            .execute()
+        )
+        all_rows.extend(result.data)
+        if len(result.data) < page_size:
+            break
+        offset += page_size
+    return sorted({r["collection"] for r in all_rows})
 
 
 def get_existing_chunks(original_filename: str) -> set[int]:

--- a/lib/db.py
+++ b/lib/db.py
@@ -1,8 +1,5 @@
 import os
 from supabase import create_client, Client
-from dotenv import load_dotenv
-
-load_dotenv()
 
 _client: Client | None = None
 
@@ -116,7 +113,13 @@ def delete_by_filename(original_filename: str) -> int:
 
 
 def get_stats() -> dict:
-    rows = get_all_documents()
+    result = (
+        get_client()
+        .table("documents")
+        .select("content_type")
+        .execute()
+    )
+    rows = result.data
     total = len(rows)
     by_type: dict[str, int] = {}
     for r in rows:

--- a/lib/embedder.py
+++ b/lib/embedder.py
@@ -84,5 +84,29 @@ def embed_pdf_page_bytes(
     return _embed_with_retry(part, task_type)
 
 
+def embed_batch(
+    contents_list: list,
+    task_type: str = "RETRIEVAL_DOCUMENT",
+) -> list[list[float]]:
+    """Embed multiple contents in a single API call.
+
+    Returns a list of normalized embedding vectors, one per input.
+    """
+    for attempt in range(MAX_RETRIES):
+        try:
+            response = get_client().models.embed_content(
+                model=MODEL,
+                contents=contents_list,
+                config=types.EmbedContentConfig(task_type=task_type),
+            )
+            return [_normalize(e.values) for e in response.embeddings]
+        except _RETRYABLE as e:
+            if attempt == MAX_RETRIES - 1:
+                raise
+            delay = RETRY_BASE_DELAY * (2 ** attempt)
+            print(f"Batch embed failed ({e}), retrying in {delay}s...")
+            time.sleep(delay)
+
+
 def embed_query(text: str) -> list[float]:
     return embed_text(text, task_type="RETRIEVAL_QUERY")

--- a/lib/embedder.py
+++ b/lib/embedder.py
@@ -1,24 +1,20 @@
-import os
 import time
 import numpy as np
-from google import genai
 from google.genai import types
-from dotenv import load_dotenv
-
-load_dotenv()
+from google.api_core import exceptions as gax_exceptions
+from lib.gemini_client import get_client
 
 MODEL = "gemini-embedding-2-preview"
 MAX_RETRIES = 3
 RETRY_BASE_DELAY = 60  # seconds
 
-_client: genai.Client | None = None
-
-
-def get_client() -> genai.Client:
-    global _client
-    if _client is None:
-        _client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
-    return _client
+_RETRYABLE = (
+    gax_exceptions.ResourceExhausted,
+    gax_exceptions.ServiceUnavailable,
+    gax_exceptions.DeadlineExceeded,
+    gax_exceptions.InternalServerError,
+    ConnectionError,
+)
 
 
 def _normalize(vec: list[float]) -> list[float]:
@@ -38,10 +34,10 @@ def _embed_with_retry(contents, task_type: str) -> list[float]:
                 config=types.EmbedContentConfig(task_type=task_type),
             )
             return _normalize(response.embeddings[0].values)
-        except Exception as e:
+        except _RETRYABLE as e:
             if attempt == MAX_RETRIES - 1:
                 raise
-            delay = RETRY_BASE_DELAY * (2 ** attempt)  # 60s, 120s, 240s
+            delay = RETRY_BASE_DELAY * (2 ** attempt)
             print(f"Embedding failed ({e}), retrying in {delay}s...")
             time.sleep(delay)
 

--- a/lib/gemini_client.py
+++ b/lib/gemini_client.py
@@ -1,0 +1,12 @@
+"""Shared Gemini client singleton."""
+import os
+from google import genai
+
+_client: genai.Client | None = None
+
+
+def get_client() -> genai.Client:
+    global _client
+    if _client is None:
+        _client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+    return _client

--- a/lib/rag.py
+++ b/lib/rag.py
@@ -143,6 +143,7 @@ def ingest(
                 continue
             _progress(f"Embedding audio chunk {i+1}/{total}", i + 1, total)
             vec = embedder.embed_audio(chunk_bytes, mime_type=mime_type)
+            b64 = base64.b64encode(chunk_bytes).decode("ascii")
             row = db.insert_document(
                 title=title,
                 content_type="audio",
@@ -150,9 +151,10 @@ def ingest(
                 chunk_index=i,
                 chunk_total=total,
                 text_content=None,
-                metadata={"format": fmt, "chunk_seconds": 75},
+                metadata={"format": fmt, "chunk_seconds": 75, "mime_type": mime_type},
                 embedding=vec,
                 collection=collection,
+                file_data=b64,
             )
             results.append(row)
 

--- a/lib/rag.py
+++ b/lib/rag.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import base64
-import fitz
 from lib import embedder, db, reasoning, chunker
 
 MIME_MAP = {
@@ -37,7 +36,7 @@ def detect_content_type(mime: str, filename: str) -> str:
     if mime in MIME_MAP:
         return MIME_MAP[mime]
     ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
-    if ext == "txt":
+    if ext in ("txt", "md"):
         return "text"
     if ext in ("png", "jpg", "jpeg", "webp", "gif"):
         return "image"
@@ -119,8 +118,7 @@ def ingest(
                 _progress(f"Skipping PDF chunk {i+1}/{total} (exists)", i + 1, total)
                 continue
             _progress(f"Embedding PDF chunk {i+1}/{total}", i + 1, total)
-            text = chunker.extract_pdf_text(pdf_bytes)
-            page_count = len(fitz.open(stream=pdf_bytes, filetype="pdf"))
+            text, page_count = chunker.extract_pdf_text(pdf_bytes)
             vec = embedder.embed_pdf_page_bytes(pdf_bytes)
             row = db.insert_document(
                 title=title,

--- a/lib/rag.py
+++ b/lib/rag.py
@@ -66,28 +66,33 @@ def ingest(
         if on_progress:
             on_progress(msg, current, total)
 
+    BATCH_SIZE = 10
+
     if content_type == "text":
         text = file_bytes.decode("utf-8", errors="replace")
         chunks = chunker.chunk_text(text)
         total = len(chunks)
-        for i, chunk_text in enumerate(chunks):
-            if i in existing:
-                _progress(f"Skipping text chunk {i+1}/{total} (exists)", i + 1, total)
-                continue
-            _progress(f"Embedding text chunk {i+1}/{total}", i + 1, total)
-            vec = embedder.embed_text(chunk_text)
-            row = db.insert_document(
-                title=title,
-                content_type="text",
-                original_filename=filename,
-                chunk_index=i,
-                chunk_total=total,
-                text_content=chunk_text,
-                metadata={"char_count": len(chunk_text)},
-                embedding=vec,
-                collection=collection,
-            )
-            results.append(row)
+        # Collect chunks to embed in batches
+        to_embed = [(i, ct) for i, ct in enumerate(chunks) if i not in existing]
+        for skip_i in (i for i in range(total) if i in existing):
+            _progress(f"Skipping text chunk {skip_i+1}/{total} (exists)", skip_i + 1, total)
+        for batch_start in range(0, len(to_embed), BATCH_SIZE):
+            batch = to_embed[batch_start:batch_start + BATCH_SIZE]
+            _progress(f"Embedding text chunks {batch[0][0]+1}-{batch[-1][0]+1}/{total}", batch[-1][0] + 1, total)
+            vecs = embedder.embed_batch([ct for _, ct in batch])
+            for (i, chunk_text), vec in zip(batch, vecs):
+                row = db.insert_document(
+                    title=title,
+                    content_type="text",
+                    original_filename=filename,
+                    chunk_index=i,
+                    chunk_total=total,
+                    text_content=chunk_text,
+                    metadata={"char_count": len(chunk_text)},
+                    embedding=vec,
+                    collection=collection,
+                )
+                results.append(row)
 
     elif content_type == "image":
         if 0 in existing:
@@ -111,27 +116,54 @@ def ingest(
             results.append(row)
 
     elif content_type == "pdf":
+        from google.genai import types as gtypes
         pdf_chunks = chunker.chunk_pdf(file_bytes)
         total = len(pdf_chunks)
+        # Extract text and filter existing
+        to_embed = []
         for i, pdf_bytes in enumerate(pdf_chunks):
             if i in existing:
                 _progress(f"Skipping PDF chunk {i+1}/{total} (exists)", i + 1, total)
                 continue
-            _progress(f"Embedding PDF chunk {i+1}/{total}", i + 1, total)
             text, page_count = chunker.extract_pdf_text(pdf_bytes)
-            vec = embedder.embed_pdf_page_bytes(pdf_bytes)
-            row = db.insert_document(
-                title=title,
-                content_type="pdf",
-                original_filename=filename,
-                chunk_index=i,
-                chunk_total=total,
-                text_content=text[:10000] if text else None,
-                metadata={"chunk_pages": page_count},
-                embedding=vec,
-                collection=collection,
+            to_embed.append((i, pdf_bytes, text, page_count))
+        # Batch embed PDF parts
+        for batch_start in range(0, len(to_embed), BATCH_SIZE):
+            batch = to_embed[batch_start:batch_start + BATCH_SIZE]
+            _progress(
+                f"Embedding PDF chunks {batch[0][0]+1}-{batch[-1][0]+1}/{total}",
+                batch[-1][0] + 1, total,
             )
-            results.append(row)
+            parts = [
+                gtypes.Part.from_bytes(data=pb, mime_type="application/pdf")
+                for _, pb, _, _ in batch
+            ]
+            try:
+                vecs = embedder.embed_batch(parts)
+            except Exception:
+                # Batch failed — fall back to individual text embeds
+                print(f"PDF batch embed failed, falling back to text")
+                vecs = []
+                for _, _, text, _ in batch:
+                    if text and text.strip():
+                        vecs.append(embedder.embed_text(text[:8000]))
+                    else:
+                        vecs.append(None)
+            for (i, _, text, page_count), vec in zip(batch, vecs):
+                if vec is None:
+                    continue
+                row = db.insert_document(
+                    title=title,
+                    content_type="pdf",
+                    original_filename=filename,
+                    chunk_index=i,
+                    chunk_total=total,
+                    text_content=text[:10000] if text else None,
+                    metadata={"chunk_pages": page_count},
+                    embedding=vec,
+                    collection=collection,
+                )
+                results.append(row)
 
     elif content_type == "audio":
         fmt = AUDIO_FMT.get(mime_type, "mp3")

--- a/lib/reasoning.py
+++ b/lib/reasoning.py
@@ -1,18 +1,7 @@
-import os
-from google import genai
 from google.genai import types
-from dotenv import load_dotenv
+from lib.gemini_client import get_client
 
-load_dotenv()
-
-_client: genai.Client | None = None
-
-
-def get_client() -> genai.Client:
-    global _client
-    if _client is None:
-        _client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
-    return _client
+REASONING_MODEL = "gemini-3.1-flash-lite-preview"
 
 
 def reason(query: str, context_chunks: list[dict]) -> str:
@@ -35,10 +24,10 @@ def reason(query: str, context_chunks: list[dict]) -> str:
     )
 
     response = get_client().models.generate_content(
-        model="gemini-3.1-flash-lite-preview",
+        model=REASONING_MODEL,
         contents=f"Context:\n{context_str}\n\nQuestion: {query}",
         config=types.GenerateContentConfig(
             system_instruction=system_instruction,
         ),
     )
-    return response.text
+    return response.text or ""

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,120 @@
+"""MCP server exposing RAG search over embedded documents."""
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from mcp.server.fastmcp import FastMCP
+from lib import rag, db
+
+mcp = FastMCP("multimodal-rag")
+
+
+@mcp.tool()
+def search_documents(
+    query: str,
+    top_k: int = 10,
+    threshold: float = 0.3,
+    content_type: str = "all",
+    collection: str = "all",
+) -> str:
+    """Search embedded documents using semantic vector search.
+
+    Args:
+        query: Natural language search query
+        top_k: Maximum number of results to return (1-50)
+        threshold: Minimum similarity threshold (0.0-1.0)
+        content_type: Filter by type: all, text, image, pdf, audio, video
+        collection: Filter by collection name, or "all" for all collections
+    """
+    result = rag.query(
+        query_text=query,
+        top_k=top_k,
+        threshold=threshold,
+        filter_type=content_type,
+        filter_collection=collection,
+        use_reasoning=False,
+    )
+
+    sources = result["sources"]
+    if not sources:
+        return "No matching documents found."
+
+    parts = []
+    for src in sources:
+        sim = src.get("similarity", 0)
+        title = src.get("title", "")
+        filename = src.get("original_filename", "")
+        ctype = src.get("content_type", "")
+        chunk = src.get("chunk_index", 0)
+        total = src.get("chunk_total", 1)
+        collection_name = src.get("collection", "")
+        text = src.get("text_content") or "(non-text content)"
+
+        parts.append(
+            f"[{sim:.3f}] {title} — {filename} "
+            f"(chunk {chunk}/{total}, {ctype}, collection: {collection_name})\n"
+            f"{text[:3000]}"
+        )
+
+    return f"Found {len(sources)} results:\n\n" + "\n\n---\n\n".join(parts)
+
+
+@mcp.tool()
+def search_and_reason(
+    query: str,
+    top_k: int = 10,
+    threshold: float = 0.3,
+    content_type: str = "all",
+    collection: str = "all",
+) -> str:
+    """Search documents and generate a reasoned answer using Gemini Flash Lite.
+
+    Args:
+        query: Natural language question
+        top_k: Maximum number of source documents (1-50)
+        threshold: Minimum similarity threshold (0.0-1.0)
+        content_type: Filter by type: all, text, image, pdf, audio, video
+        collection: Filter by collection name, or "all" for all collections
+    """
+    result = rag.query(
+        query_text=query,
+        top_k=top_k,
+        threshold=threshold,
+        filter_type=content_type,
+        filter_collection=collection,
+        use_reasoning=True,
+    )
+
+    answer = result.get("answer") or "No answer generated."
+    sources = result["sources"]
+
+    source_list = "\n".join(
+        f"- [{s.get('similarity', 0):.3f}] {s.get('title', '')} — {s.get('original_filename', '')} "
+        f"(chunk {s.get('chunk_index', 0)}/{s.get('chunk_total', 1)}, {s.get('collection', '')})"
+        for s in sources
+    )
+
+    return f"Answer:\n{answer}\n\nSources ({len(sources)}):\n{source_list}"
+
+
+@mcp.tool()
+def list_collections() -> str:
+    """List all available document collections."""
+    collections = db.get_collections()
+    if not collections:
+        return "No collections found."
+    return "Collections:\n" + "\n".join(f"- {c}" for c in collections)
+
+
+@mcp.tool()
+def document_stats() -> str:
+    """Show database statistics: total documents and counts per content type."""
+    stats = db.get_stats()
+    lines = [f"Total chunks: {stats['total']}"]
+    for ctype, count in stats["by_type"].items():
+        lines.append(f"- {ctype}: {count}")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,96 @@
+-- Schema for multimodal-rag
+-- Run this once against a fresh Supabase project.
+
+-- 1. Enable pgvector
+create extension if not exists vector with schema extensions;
+
+-- 2. Documents table
+create table if not exists public.documents (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  content_type text not null,
+  original_filename text not null,
+  chunk_index integer not null default 0,
+  chunk_total integer not null default 1,
+  text_content text,
+  metadata jsonb default '{}'::jsonb,
+  embedding vector(3072) not null,
+  file_data text,
+  collection text not null default 'default',
+  created_at timestamptz not null default now()
+);
+
+-- 3. Row Level Security
+alter table public.documents enable row level security;
+
+create policy "Service key full access"
+  on public.documents
+  for all
+  using (true)
+  with check (true);
+
+-- 4. Vector search RPC
+create or replace function public.match_documents(
+  query_embedding vector(3072),
+  match_threshold float default 0.5,
+  match_count int default 10,
+  filter_type text default null,
+  filter_collection text default null
+)
+returns table (
+  id uuid,
+  title text,
+  content_type text,
+  original_filename text,
+  chunk_index integer,
+  chunk_total integer,
+  text_content text,
+  metadata jsonb,
+  file_data text,
+  collection text,
+  similarity float
+)
+language plpgsql stable as $$
+begin
+  return query
+  select
+    d.id,
+    d.title,
+    d.content_type,
+    d.original_filename,
+    d.chunk_index,
+    d.chunk_total,
+    d.text_content,
+    d.metadata,
+    d.file_data,
+    d.collection,
+    1 - (d.embedding <=> query_embedding)::float as similarity
+  from public.documents d
+  where
+    (filter_type is null or d.content_type = filter_type)
+    and (filter_collection is null
+         or d.collection = filter_collection)
+    and 1 - (d.embedding <=> query_embedding)
+        >= match_threshold
+  order by d.embedding <=> query_embedding
+  limit match_count;
+end;
+$$;
+
+-- 5. Distinct collections RPC
+create or replace function public.get_distinct_collections()
+returns table(collection text)
+language sql stable as $$
+  select distinct d.collection
+  from public.documents d
+  order by d.collection;
+$$;
+
+-- 6. Document stats RPC
+create or replace function public.get_document_stats()
+returns table(content_type text, cnt bigint)
+language sql stable as $$
+  select d.content_type, count(*) as cnt
+  from public.documents d
+  group by d.content_type;
+$$;


### PR DESCRIPTION
## Summary

Follow-up improvements building on PR #1.

### Bug Fixes

- **Audio bytes not stored in database** (fixes #4) — audio
  chunks now store bytes as Base64 in `file_data` with
  `mime_type` in metadata, enabling playback
- **Stats/Browse/Collections capped at 1000 rows** — Supabase
  PostgREST returns max 1000 rows by default; fixed via
  pagination for `get_all_documents()` and dedicated RPC
  functions for `get_collections()` and `get_stats()`

### Performance

- **Batch embedding** for text and PDF chunks — up to 10
  chunks per API call, reducing network overhead ~10x.
  PDF batches fall back to individual text embeds on failure.
  Audio/video remain single-call (large binary payloads).
- **RPC functions** for collections and stats — single SQL
  query with `DISTINCT` / `GROUP BY` instead of fetching
  all rows client-side. No pagination needed.

### Code Quality

- Shared Gemini client singleton (`lib/gemini_client.py`)
- Remove `load_dotenv()` from library modules
- Scope embedding retry to transient errors only
  (429, 503, timeout)
- Context managers for all `fitz.open()` calls
- Combine `extract_pdf_text()` to return
  `(text, page_count)` tuple
- Fix video chunking temp file leak, remove dead code
- Reasoning model name as module constant,
  handle `None` response

### New Features

- **MCP server** (`mcp_server.py`): 4 tools —
  `search_documents`, `search_and_reason`,
  `list_collections`, `document_stats`
- **PDF fallback**: when binary embedding fails,
  automatically falls back to text embedding
- **Markdown (.md) file upload support**
- **File uploader resets** after successful upload

### Database Migrations

- `get_distinct_collections()` — `SELECT DISTINCT
  collection` via RPC
- `get_document_stats()` — `GROUP BY content_type`
  with count via RPC

### Docs & Config

- `.env.example` with documented config options
- Updated `CLAUDE.md` with full schema and design decisions
- Updated `README.md` with MCP server docs
- Fix all markdownlint errors across `.md` files

## Test plan

- [x] Audio upload -> verify `file_data` stored in DB
- [x] Stats show correct count beyond 1000 chunks
- [x] Browse tab lists all documents beyond 1000
- [x] Collections dropdown shows all 19 collections
- [x] Batch embedding: 10er blocks in progress output
- [x] PDF with INVALID_ARGUMENT -> falls back to text
- [x] MCP server tools functional
- [x] File uploader clears after upload
- [x] All markdown files pass markdownlint
- [ ] Multi-file upload in one batch